### PR TITLE
ユーザ情報APIの組織一覧が取れない不具合の修正

### DIFF
--- a/src/main/scala/net/mtgto/garoon/user/User.scala
+++ b/src/main/scala/net/mtgto/garoon/user/User.scala
@@ -35,7 +35,7 @@ object User {
     val identity = UserId((node \ "@key").text)
     val name = (node \ "@name").text
     val loginName = (node \ "@login_name").text
-    val organizationIds = (node \ "organization" \ "@id").map(id => OrganizationId(id.text))
+    val organizationIds = (node \ "organization").map(n => OrganizationId((n \ "@id").text))
     val primaryOrganizationId = (node \ "@primary_organization").headOption.map(id => OrganizationId(id.text))
     DefaultUser(identity, name, loginName, organizationIds, primaryOrganizationId)
   }


### PR DESCRIPTION
### このpull requestが解決する問題
- ユーザ情報取得APIでorganization一覧を正しくパースできていない不具合を修正します。
### 参考URL
- ユーザ情報を取得する https://cybozudev.zendesk.com/hc/ja/articles/202283324-%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B
